### PR TITLE
Add support for collapsing form_class

### DIFF
--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -11,8 +11,8 @@ export class Decorator {
     unfoldIfLineSelected: boolean = false
     supportedLanguages: string[] = []
 
-    // Matches class="..." or className="..." or class: "..." or className: "..."
-    public regEx = /(class|className)(=|:|:\s)(['"`]|{(['"`]))(.*?)(\3|\4})/g
+    // Matches class="..." or className="..." or class: "..." or className: "..." or form_class: "..."
+    public regEx = /(class|className|form_class)(=|:|:\s)(['"`]|{(['"`]))(.*?)(\3|\4})/g
 
     regExGroup = 0
 

--- a/src/tests/decorator.test.ts
+++ b/src/tests/decorator.test.ts
@@ -102,4 +102,9 @@ describe('className Regex Tests', () => {
     expect(input.match(regex)).not.toBeNull();
   });
 
+  test('Maches form_class attribute', () => {
+    const input = "<%= button_to 'Add to Cart', line_items_path(product_id: product), form_class: 'inline' %>";
+    expect(input.match(regex)).not.toBeNull();
+  });
+
 });


### PR DESCRIPTION
In Rails, there are situations where we need to use `form_class:`, for example, when using the `button_to` helper. The `button_to` helper creates an HTML `<form>` tag wrapping the `<button>` tag.